### PR TITLE
Fixing importlib.resources  preventing import by replacing with importlib_resources

### DIFF
--- a/exoatlas/imports.py
+++ b/exoatlas/imports.py
@@ -1,8 +1,8 @@
 # imports that are need by many exoatlas subsections
-import os, sys, time, shutil, warnings, copy, importlib
+import os, sys, time, shutil, warnings, copy, importlib_resources
 from tqdm import tqdm
 
-code_directory = importlib.resources.files(__name__)
+code_directory = importlib_resources.files(__name__)
 
 
 import numpy as np, matplotlib.pyplot as plt, matplotlib.animation as animation


### PR DESCRIPTION
A fresh conda environment with only the current version of exoatlas and its dependencies failed to import despite successful installation. The reason seems to be as simple as importlib.resources now being packaged in importlib_resources, but I don't know what version dependencies are affected.